### PR TITLE
fix #22

### DIFF
--- a/website_multi_image/static/js/slick/slick.js
+++ b/website_multi_image/static/js/slick/slick.js
@@ -1562,7 +1562,8 @@
     Slick.prototype.selectHandler = function(event) {
 
         var _ = this;
-        var index = parseInt($(event.target).parents('.slick-slide').attr("index"));
+        var slide = $(event.target).parents('.slick-slide');
+        var index = $(event.target).parents('.slick-track').children().index(slide);
         if(!index) index = 0;
 
         if(_.slideCount <= _.options.slidesToShow){


### PR DESCRIPTION
in synced sliders, use natural ordering of slides instead of `index` attribute to navigate with mouse clicks, cos filtering could be applied
